### PR TITLE
FTBFS (Coq 8.18.0)

### DIFF
--- a/CutSequent.v
+++ b/CutSequent.v
@@ -25,7 +25,7 @@
 
 (* proof of the sub-formula property in the sequent calculus *)
 Require Import Arith.
-Require Import Max.
+Require Import Lia.
 Require Export Sequent.
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -37,11 +37,8 @@ Proof.
  intros m n H.
  cut (m <= 0).
  intro.
- cut (0 = m); auto. 
- apply le_n_O_eq.
- assumption.
- rewrite <- H.
- apply le_max_l.
+ cut (0 = m); auto.
+ all: lia.
 Qed.
 
 Lemma maxNatR : forall n m : nat, max n m = 0 -> m = 0.
@@ -50,10 +47,7 @@ Proof.
  cut (0 = m'); auto.
  cut (m' <= 0).
  intro.
- apply le_n_O_eq.
- assumption.
- rewrite <- H.
- auto with arith.
+ all: lia.
 Qed.
 (* end of arithmetic part *)
 
@@ -291,7 +285,7 @@ Lemma notCutFree :
  generalize H1.
  cut (~ 1 <= 0).
  auto.
- apply le_Sn_O.
+ lia.
  cut (max (degreeFormula A) (degreeProof p1) = 0).
  intro; eapply maxNatL; eauto.
  eapply maxNatL; eauto.

--- a/Form.v
+++ b/Form.v
@@ -492,9 +492,11 @@ End weaken.
 End CTL_def.
 
 
+(* NOTE: no more supported in newer Coq versions
 Implicit Arguments Dot [Atoms].
 Implicit Arguments Slash [Atoms].
 Implicit Arguments Backslash [Atoms].
+ *)
 
 
 Hint Resolve one comp beta gamma arrow_plus: ctl.

--- a/GentzenDed.v
+++ b/GentzenDed.v
@@ -91,9 +91,8 @@ Definition condCutExt (X : gentzen_extension) :=
   forall (Atoms:Set)(T T1 T2 T3 : Term Atoms) (A : Form Atoms),
   X _ T1 T2 ->
   replace T2 T (OneForm A) T3 ->
-  sigS
+  sigT
     (fun T' : Term Atoms => (X _ T' T * replace T1 T' (OneForm A) T3)%type).
-       
 
 
 Definition conditionOKNLP : condCutExt NLP_Sequent.

--- a/ReplaceProp.v
+++ b/ReplaceProp.v
@@ -146,11 +146,11 @@ Qed.
 Lemma replace_inv2 :
  forall (Gamma1 Gamma2 Gamma' Delta : Term Atoms) (X : Form Atoms),
  replace (Comma Gamma1 Gamma2) Gamma' (OneForm X) Delta ->
- sigS
+ sigT
    (fun Gamma'1 : Term Atoms =>
     {x_ : replace Gamma1 Gamma'1 (OneForm X) Delta |
     Gamma' = Comma Gamma'1 Gamma2}) +
- sigS
+ sigT
    (fun Gamma'2 : Term Atoms =>
     {x_ : replace Gamma2 Gamma'2 (OneForm X) Delta |
     Gamma' = Comma Gamma1 Gamma'2}).
@@ -166,10 +166,10 @@ Definition doubleReplace :
   replace Gamma Gamma' T1 T2 ->
   forall Gamma2 : Term Atoms,
   replace Gamma' Gamma2 (OneForm A) T3 ->
-  sigS
+  sigT
     (fun T : Term Atoms =>
      (replace Gamma T (OneForm A) T3 * replace T Gamma2 T1 T2)%type) +
-  sigS
+  sigT
     (fun T : Term Atoms =>
      (replace T2 T (OneForm A) T3 * replace Gamma Gamma2 T1 T)%type).
 
@@ -232,7 +232,7 @@ Definition replaceSameP :
   forall T1 T2 T3 T4 : Term Atoms,
   replace T1 T2 T3 T4 ->
   forall T : Term Atoms,
-  sigS
+  sigT
     (fun T' : Term Atoms => (replace T1 T' T3 T * replace T' T2 T T4)%type). 
  simple induction 1.
  intros.


### PR DESCRIPTION
Hi,

This PR contains a minimal patch to support building of your code in Coq 8.18.0. There's a log of compilation shown at the end. The fix is actually done by my colleague Ian Shillito (@ianshil).

Regards,

Chun TIAN

```
$ make
make -f Makefile.coq Makefile
COQDEP VFILES
make[1]: Nothing to be done for `Makefile'.
make -f Makefile.coq all
COQC Form.v
COQC Terms.v
COQC ReplaceProp.v
COQC Sequent.v
COQC NaturalDeduction.v
COQC GentzenDed.v
COQC ArrowGentzen.v
COQC ArrowDed.v
COQC CutSequent.v
COQC LSeqProp.v
File "./LSeqProp.v", line 239, characters 0-32:
Warning: Use of “Require” inside a section is fragile. It is not recommended
to use this functionality in finished proof scripts.
[require-in-section,fragile,default]
COQC Tactics.v
File "./Tactics.v", line 59, characters 8-13:
Warning: Unused variable other might be a misspelled constructor. Use _ or
_other to silence this warning. [unused-pattern-matching-variable,default]
File "./Tactics.v", line 61, characters 4-9:
Warning: Unused variable other might be a misspelled constructor. Use _ or
_other to silence this warning. [unused-pattern-matching-variable,default]
File "./Tactics.v", line 74, characters 12-17:
Warning: Unused variable other might be a misspelled constructor. Use _ or
_other to silence this warning. [unused-pattern-matching-variable,default]
File "./Tactics.v", line 76, characters 8-13:
Warning: Unused variable other might be a misspelled constructor. Use _ or
_other to silence this warning. [unused-pattern-matching-variable,default]
File "./Tactics.v", line 89, characters 12-17:
Warning: Unused variable other might be a misspelled constructor. Use _ or
_other to silence this warning. [unused-pattern-matching-variable,default]
File "./Tactics.v", line 91, characters 8-13:
Warning: Unused variable other might be a misspelled constructor. Use _ or
_other to silence this warning. [unused-pattern-matching-variable,default]
COQC ExampleNatDed2.v
COQC ExampleNatDed3.v
COQC ExampleNatDed.v
COQC Polarity.v
COQC ExamplePol.v
COQC Filters.v
COQC Semantics.v
```
